### PR TITLE
Bugfix for incorrect output of group name and description in Grouper backend

### DIFF
--- a/src/main/java/voot/provider/GrouperDaoClient.java
+++ b/src/main/java/voot/provider/GrouperDaoClient.java
@@ -35,8 +35,8 @@ public class GrouperDaoClient implements GrouperDao {
         " and (gf.name = 'admins' or gf.name = 'updaters' or gf.name = 'members') order by gg.name",
       new Object[]{subjectId},
       (resultSet, i) ->
-        new Group(groupIdPrefix + resultSet.getString("groupname"), resultSet.getString("groupname"),
-          resultSet.getString("display_extension"), sourceId, membership(resultSet))
+        new Group(groupIdPrefix + resultSet.getString("groupname"), resultSet.getString("display_extension"),
+          resultSet.getString("description"), sourceId, membership(resultSet))
     );
     //the query returns duplicate groups because you can have multiple roles for one team
     Map<String, List<Group>> collect = groups.stream().collect(Collectors.groupingBy(group -> group.id));

--- a/src/test/java/voot/provider/GrouperDaoClientTest.java
+++ b/src/test/java/voot/provider/GrouperDaoClientTest.java
@@ -45,9 +45,32 @@ public class GrouperDaoClientTest {
     assertMembership(groups, PREFIX + "nl:surfnet:diensten:burr", Membership.MANAGER);
     assertMembership(groups, PREFIX + "nl:surfnet:diensten:managementvo", Membership.MANAGER);
     assertMembership(groups, PREFIX + "nl:surfnet:diensten:test123", Membership.MEMBER);
+
+    assertDisplayName(groups, PREFIX + "nl:surfnet:diensten:bassie_&_adriaan", "bassie & adriaan");
+    assertDisplayName(groups, PREFIX + "nl:surfnet:diensten:bazenteam", "Bazenteam");
+    assertDisplayName(groups, PREFIX + "nl:surfnet:diensten:burr", "burr");
+    assertDisplayName(groups, PREFIX + "nl:surfnet:diensten:test123", "test123");
+
+    assertDescription(groups, PREFIX + "nl:surfnet:diensten:bazenteam", "Eh");
+    assertDescription(groups, PREFIX + "nl:surfnet:diensten:burr", "fffff");
+    assertDescription(groups, PREFIX + "nl:surfnet:diensten:test123", "Testteam");
+
+    assertSourceID(groups, PREFIX + "nl:surfnet:diensten:bazenteam", "grouper");
   }
 
   private void assertMembership(List<Group> groups, String groupId, Membership membership) {
-    assertEquals(groupId, groups.stream().filter(group -> group.id.equals(groupId)).collect(toList()).get(0).membership, membership);
+    assertEquals(groupId, membership, groups.stream().filter(group -> group.id.equals(groupId)).collect(toList()).get(0).membership);
+  }
+
+  private void assertDisplayName(List<Group> groups, String groupId, String displayName) {
+    assertEquals(groupId, displayName, groups.stream().filter(group -> group.id.equals(groupId)).collect(toList()).get(0).displayName);
+  }
+
+  private void assertDescription(List<Group> groups, String groupId, String description) {
+    assertEquals(groupId, description, groups.stream().filter(group -> group.id.equals(groupId)).collect(toList()).get(0).description);
+  }
+
+  private void assertSourceID(List<Group> groups, String groupId, String sourceID) {
+    assertEquals(groupId, sourceID, groups.stream().filter(group -> group.id.equals(groupId)).collect(toList()).get(0).sourceID);
   }
 }


### PR DESCRIPTION
Voot would output group ID in name, and group name in the description field. Bug introduced in 2.0.0.