### PR TITLE
Disable HTTP keep-alive to fix test hangs

### DIFF
--- a/src/test/java/voot/oauth/AbstractRemoteTokenServicesTest.java
+++ b/src/test/java/voot/oauth/AbstractRemoteTokenServicesTest.java
@@ -1,6 +1,7 @@
 package voot.oauth;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.core.io.ClassPathResource;
@@ -39,6 +40,11 @@ public abstract class AbstractRemoteTokenServicesTest {
   protected abstract String getFailureCheckTokenJsonPath();
   protected abstract String getErrorCheckTokenJsonPath();
   protected abstract String getSuccesCheckTokenClientCredentialsJsonPath();
+
+  @BeforeClass
+  public static void disableKeepAlive() {
+    System.setProperty("http.keepAlive", "false");
+  }
 
   @Test
   public void testLoadAuthenticationSuccess() throws Exception {


### PR DESCRIPTION
This provides the same fix that we used for OpenConext-PDP.

I should note: the reason this works is because `System.setProperty` runs on this test that seemed to be the first-running test. If this specific test doesn't run first, it could run into the same issue as before. I don't know JUnit as much as you guys probably do, so if there's a better way to more reliably call `System.setProperty` before testing, go for it (also applying to the PDP patch).

Cheers,
Andrew