### PR TITLE
Return HTTP 400 for firewall-rejected requests instead of logging ERROR

### DIFF
--- a/src/main/java/voot/security/SecurityConfig.java
+++ b/src/main/java/voot/security/SecurityConfig.java
@@ -8,6 +8,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.firewall.HttpStatusRequestRejectedHandler;
+import org.springframework.security.web.firewall.RequestRejectedHandler;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -46,6 +48,14 @@ public class SecurityConfig implements WebMvcConfigurer {
                 .oauth2ResourceServer(oauth2 -> oauth2.opaqueToken(token -> token
                         .introspector(new CachingOpaqueTokenIntrospector(introspectionUri, clientId, secret, cacheTokens))));
         return http.build();
+    }
+
+    @Bean
+    public RequestRejectedHandler requestRejectedHandler() {
+        // Return HTTP 400 for malicious/malformed requests (scanner probes with ;, encoded slashes, etc.)
+        // instead of propagating RequestRejectedException up to Tomcat as ERROR.
+        // StrictHttpFirewall correctly rejects these - we just want clean 400 responses without error logs/emails.
+        return new HttpStatusRequestRejectedHandler();
     }
 
     @Override

--- a/src/test/java/voot/VootControllerTest.java
+++ b/src/test/java/voot/VootControllerTest.java
@@ -237,4 +237,17 @@ public class VootControllerTest extends AbstractTest {
                 .statusCode(403);
     }
 
+    @Test
+    void testFirewallRejectsMaliciousRequest() {
+        // Verify that StrictHttpFirewall rejects malicious scanner requests (semicolons, encoded slashes, etc.)
+        // with HTTP 400 via RequestRejectedHandler, WITHOUT reaching authentication or logging ERROR.
+        // The firewall blocks the request before any auth processing, so no token is needed.
+        given()
+                .when()
+                .accept(ContentType.JSON)
+                .get("/me/groups;malicious=probe")
+                .then()
+                .statusCode(400);
+    }
+
 }


### PR DESCRIPTION
## Summary

Automated scanners frequently send malformed request paths (containing `;`, encoded
slashes, `.env`, `.git/config`, etc.). Spring Security's `StrictHttpFirewall` correctly
rejects these with a `RequestRejectedException`. However, the default
`DefaultRequestRejectedHandler` **rethrows** the exception, so it propagates up to
Tomcat's `ErrorReportValve` and is logged at **ERROR** with a full stack trace.

In deployments where a log/SMTP appender is bound at ERROR level, this produces alert
spam for expected, correctly-blocked traffic.

## Current behavior (log)

A malicious scanner request results in the following ERROR being logged:

```
2026-07-17 07:47:04,813 ERROR [http-nio-8080-exec-1] o.a.c.c.C.[.[.[/].[dispatcherServlet]:175 - Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception
org.springframework.security.web.firewall.RequestRejectedException: The request was rejected because the URL contained a potentially malicious String ";"
    at org.springframework.security.web.firewall.StrictHttpFirewall.rejectedBlocklistedUrls(StrictHttpFirewall.java:535)
    at org.springframework.security.web.firewall.StrictHttpFirewall.getFirewalledRequest(StrictHttpFirewall.java:505)
    at org.springframework.security.web.FilterChainProxy.doFilterInternal(FilterChainProxy.java:206)
    at org.springframework.security.web.FilterChainProxy.doFilter(FilterChainProxy.java:186)
    at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:354)
    ...
    at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93)
    at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74)
    at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:342)
    ...
    at java.base/java.lang.Thread.run(Thread.java:1583)
```

## Change

Register a `RequestRejectedHandler` bean using the built-in
`HttpStatusRequestRejectedHandler`, so firewall rejections return a clean `400 Bad
Request` without an ERROR-level log or stack trace.

```java
@Bean
public RequestRejectedHandler requestRejectedHandler() {
    return new HttpStatusRequestRejectedHandler();
}
```

The bean is auto-detected and wired into the `FilterChainProxy` by Spring Security's
`WebSecurityConfiguration` (Spring Security 6.4.x / Spring Boot 3.4.4).

## Why this is safe

- The `StrictHttpFirewall` protection is **unchanged** — malicious requests are still
  rejected exactly as before.
- Only the rejection-to-response/logging behavior changes: a clean `400` instead of a
  propagated exception logged as ERROR.
- No new attack surface, no weakened access control.

## Tests

- Added `VootControllerTest.testFirewallRejectsMaliciousRequest()` which sends a request
  with a malicious path (`/me/groups;malicious=probe`) and asserts a `400` response. The
  firewall blocks the request before authentication, so no token is required.

## Verification

**Before:** firewall rejections logged at ERROR with a full `RequestRejectedException`
stack trace (see log above), and — where configured — triggered alert emails.
**After:** the same requests return `400` with no ERROR log.